### PR TITLE
Add `build` GitHub Action to build and deploy the tutorials website

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,79 @@
+name: Build website
+
+on:
+  # Build after every push to main
+  push:
+    branches:
+      - main
+  # Build on every PR
+  pull_request:
+
+jobs:
+
+  # =================
+  # Build the website
+  # =================
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '18'
+
+      - name: Install Myst
+        run: |
+          npm install -g mystmd
+
+      - name: Build website as static HTML
+        run: |
+          myst build --html
+
+      # Store the website as a build artifact so we can deploy it later
+      - name: Upload HTML website as an artifact
+        # Only if not a pull request
+        if: success() && github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: html-${{ github.sha }}
+          path: _build/html
+
+
+  # ==================
+  # Deploy the website
+  # ==================
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name != 'pull_request'
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      # Fetch the built HTML from the build job
+      - name: Download HTML artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: html-${{ github.sha }}
+          path: _build/html
+
+      - name: Deploy to gh-pages
+        if: success() && github.event_name != 'pull_request'
+        # Don't use tags: https://julienrenaux.fr/2019/12/20/github-actions-security-risk/
+        uses: peaceiris/actions-gh-pages@v373f7f263a76c20808c831209c920827a82a2847
+        # If you're changing the branch from main,
+        # also change the `main` in `refs/heads/main`
+        # below accordingly.
+        if: github.ref == 'refs/heads/main'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: _build/html
+          publish_branch: gh-pages
+          enable_jekyll: false
+          force_orphan: true
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,10 +66,6 @@ jobs:
         if: success() && github.event_name != 'pull_request'
         # Don't use tags: https://julienrenaux.fr/2019/12/20/github-actions-security-risk/
         uses: peaceiris/actions-gh-pages@v373f7f263a76c20808c831209c920827a82a2847
-        # If you're changing the branch from main,
-        # also change the `main` in `refs/heads/main`
-        # below accordingly.
-        if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: _build/html

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
 


### PR DESCRIPTION
Create a new `build.yml` GitHub Action workflow that builds the website on every Pull Request and after every push to `main`. It's also capable to deploy the website to `gh-pages` branch after a push to `main` or a release.