### PR TITLE
Fix commit hash for peaceiris/actions-gh-pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Deploy to gh-pages
         if: success() && github.event_name != 'pull_request'
         # Don't use tags: https://julienrenaux.fr/2019/12/20/github-actions-security-risk/
-        uses: peaceiris/actions-gh-pages@v373f7f263a76c20808c831209c920827a82a2847
+        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: _build/html


### PR DESCRIPTION
Fix wrong commit hash for `peaceiris/actions-gh-pages` in the `build.yml` GH Action.
