### PR TITLE
Set BASE_URL envvar in `build.yml` to repo's name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,8 @@ jobs:
       - name: Build website as static HTML
         run: |
           myst build --html
+        env:
+          BASE_URL: "/${{ github.events.repository.name }}"
 
       # Store the website as a build artifact so we can deploy it later
       - name: Upload HTML website as an artifact


### PR DESCRIPTION
Set the BASE_URL environment variable so the website is built properly to be served with GitHub Actions. This env var is read by Myst while building the website.
