### PR TITLE
Fix typo in setting the BASE_URL env variable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,9 +31,14 @@ jobs:
 
       - name: Build website as static HTML
         run: |
+          echo "Base url: " $BASE_URL
           myst build --html
+          echo "-----------------------"
+          echo "Printing the index.html"
+          echo "-----------------------"
+          cat _build/html/index.html
         env:
-          BASE_URL: "/${{ github.events.repository.name }}"
+          BASE_URL: /${{ github.events.repository.name }}
 
       # Store the website as a build artifact so we can deploy it later
       - name: Upload HTML website as an artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,12 +31,8 @@ jobs:
 
       - name: Build website as static HTML
         run: |
-          echo "Base url: " $BASE_URL
+          echo "Building MyST website using BASE_URL=" $BASE_URL
           myst build --html
-          echo "-----------------------"
-          echo "Printing the index.html"
-          echo "-----------------------"
-          cat _build/html/index.html
         env:
           BASE_URL: /${{ github.event.repository.name }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
           echo "-----------------------"
           cat _build/html/index.html
         env:
-          BASE_URL: /${{ github.events.repository.name }}
+          BASE_URL: /${{ github.event.repository.name }}
 
       # Store the website as a build artifact so we can deploy it later
       - name: Upload HTML website as an artifact


### PR DESCRIPTION
Fix typo in github context variable while setting `BASE_URL` in `build.yml`.