### PR TITLE
Add Plausible analytics

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -26,4 +26,6 @@ site:
     - title: Learn More
       url: https://mystmd.org/guide
   domains: []
-
+  # Add Plausible analytics
+  options:
+    analytics_plausible: simpeg.xyz


### PR DESCRIPTION
Enable [Plausible analytics](https://plausible.io/) for the website using the `simpeg.xyz` domain.