### PR TITLE
Use choclo as engine in potential field simulations

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,4 +11,5 @@ dependencies:
   - nbconvert
   - simpeg==0.22.*
   - discretize==0.10.*
+  - choclo==0.3.0
   - pymatsolver

--- a/notebooks/03-gravity/fwd_gravity_anomaly_3d.ipynb
+++ b/notebooks/03-gravity/fwd_gravity_anomaly_3d.ipynb
@@ -609,7 +609,7 @@
     "    rhoMap=model_map,\n",
     "    active_cells=active_cells,\n",
     "    store_sensitivities=\"forward_only\",\n",
-    "    engine=\"geoana\",\n",
+    "    engine=\"choclo\",\n",
     ")"
    ]
   },

--- a/notebooks/03-gravity/fwd_gravity_gradiometry_3d.ipynb
+++ b/notebooks/03-gravity/fwd_gravity_gradiometry_3d.ipynb
@@ -637,7 +637,7 @@
     "    rhoMap=model_map,\n",
     "    active_cells=active_cells,\n",
     "    store_sensitivities=\"forward_only\",\n",
-    "    engine=\"geoana\",\n",
+    "    engine=\"choclo\",\n",
     ")"
    ]
   },

--- a/notebooks/03-gravity/inv_gravity_anomaly_3d.ipynb
+++ b/notebooks/03-gravity/inv_gravity_anomaly_3d.ipynb
@@ -609,7 +609,7 @@
     "    mesh=tensor_mesh,\n",
     "    rhoMap=tensor_model_map,\n",
     "    active_cells=active_tensor_cells,\n",
-    "    engine=\"geoana\",\n",
+    "    engine=\"choclo\",\n",
     ")"
    ]
   },

--- a/notebooks/04-magnetics/fwd_magnetics_induced_3d.ipynb
+++ b/notebooks/04-magnetics/fwd_magnetics_induced_3d.ipynb
@@ -601,7 +601,7 @@
     "    chiMap=model_map,\n",
     "    active_cells=active_cells,\n",
     "    store_sensitivities=\"forward_only\",\n",
-    "    engine=\"geoana\",\n",
+    "    engine=\"choclo\",\n",
     ")"
    ]
   },

--- a/notebooks/04-magnetics/fwd_magnetics_mvi_3d.ipynb
+++ b/notebooks/04-magnetics/fwd_magnetics_mvi_3d.ipynb
@@ -707,7 +707,9 @@
     "- the mapping from the model to the active cells\n",
     "- the model type: \"scalar\" for susceptibility model, \"vector\" for magnetic vector model\n",
     "\n",
-    "This is accomplished by setting each one of the aforementioned items as a property of the simulation object. Additional keyword arguments can also be set which impact the forward simulation. Because we are only simulating data for a single model, there is no benefit to storing the sensitivities for the forward simulation. ``store_sensitivities`` property to *'forward_only'*"
+    "This is accomplished by setting each one of the aforementioned items as a property of the simulation object. Additional keyword arguments can also be set which impact the forward simulation. Because we are only simulating data for a single model, there is no benefit to storing the sensitivities for the forward simulation. ``store_sensitivities`` property to *'forward_only'*\n",
+    "\n",
+    "> By choosing `engine=\"choclo\"` we can make our simulation to run the faster and more memory efficient implementation of the magnetic forward that uses [Numba](https://numba.pydata.org/) and [Choclo](https://www.fatiando.org/choclo) under the hood. To do so, we need to have [Choclo installed](https://www.fatiando.org/choclo/latest/install.html)."
    ]
   },
   {
@@ -730,6 +732,7 @@
     "    chiMap=model_map,\n",
     "    active_cells=active_cells,\n",
     "    store_sensitivities=\"forward_only\",\n",
+    "    engine=\"choclo\",\n",
     ")"
    ]
   },

--- a/notebooks/04-magnetics/inv_magnetics_induced_3d.ipynb
+++ b/notebooks/04-magnetics/inv_magnetics_induced_3d.ipynb
@@ -1281,6 +1281,7 @@
     "    model_type=\"scalar\",\n",
     "    chiMap=tree_model_map,\n",
     "    active_cells=ind_tree_active,\n",
+    "    engine=\"choclo\",\n",
     ")"
    ]
   },

--- a/notebooks/04-magnetics/inv_magnetics_induced_3d.ipynb
+++ b/notebooks/04-magnetics/inv_magnetics_induced_3d.ipynb
@@ -622,7 +622,7 @@
     "    model_type=\"scalar\",\n",
     "    chiMap=tensor_model_map,\n",
     "    active_cells=active_tensor_cells,\n",
-    "    engine=\"geoana\",\n",
+    "    engine=\"choclo\",\n",
     ")"
    ]
   },

--- a/notebooks/11-joint-inversion/plot_inv_3_cross_gradient_pf.ipynb
+++ b/notebooks/11-joint-inversion/plot_inv_3_cross_gradient_pf.ipynb
@@ -524,7 +524,11 @@
    "outputs": [],
    "source": [
     "simulation_grav = gravity.simulation.Simulation3DIntegral(\n",
-    "    survey=survey_grav, mesh=mesh, rhoMap=wires.density, active_cells=ind_active\n",
+    "    survey=survey_grav,\n",
+    "    mesh=mesh,\n",
+    "    rhoMap=wires.density,\n",
+    "    active_cells=ind_active,\n",
+    "    engine=\"choclo\",\n",
     ")\n",
     "\n",
     "simulation_mag = magnetics.simulation.Simulation3DIntegral(\n",
@@ -533,6 +537,7 @@
     "    model_type=\"scalar\",\n",
     "    chiMap=wires.susceptibility,\n",
     "    active_cells=ind_active,\n",
+    "    engine=\"choclo\",\n",
     ")"
    ]
   },

--- a/notebooks/12-pgi-inversion/plot_inv_1_joint_pf_pgi_full_info_tutorial.ipynb
+++ b/notebooks/12-pgi-inversion/plot_inv_1_joint_pf_pgi_full_info_tutorial.ipynb
@@ -376,6 +376,7 @@
     "    mesh=mesh,\n",
     "    rhoMap=wires.den,\n",
     "    active_cells=actv,\n",
+    "    engine=\"choclo\",\n",
     ")\n",
     "dmis_grav = data_misfit.L2DataMisfit(data=data_grav, simulation=simulation_grav)\n",
     "# Mag problem\n",
@@ -384,6 +385,7 @@
     "    mesh=mesh,\n",
     "    chiMap=wires.sus,\n",
     "    active_cells=actv,\n",
+    "    engine=\"choclo\",\n",
     ")\n",
     "dmis_mag = data_misfit.L2DataMisfit(data=data_mag, simulation=simulation_mag)"
    ]

--- a/notebooks/12-pgi-inversion/plot_inv_2_joint_pf_pgi_no_info_tutorial.ipynb
+++ b/notebooks/12-pgi-inversion/plot_inv_2_joint_pf_pgi_no_info_tutorial.ipynb
@@ -370,6 +370,7 @@
     "    mesh=mesh,\n",
     "    rhoMap=wires.den,\n",
     "    active_cells=actv,\n",
+    "    engine=\"choclo\",\n",
     ")\n",
     "dmis_grav = data_misfit.L2DataMisfit(data=data_grav, simulation=simulation_grav)\n",
     "# Mag problem\n",
@@ -378,6 +379,7 @@
     "    mesh=mesh,\n",
     "    chiMap=wires.sus,\n",
     "    active_cells=actv,\n",
+    "    engine=\"choclo\",\n",
     ")\n",
     "dmis_mag = data_misfit.L2DataMisfit(data=data_mag, simulation=simulation_mag)"
    ]


### PR DESCRIPTION
Choose Choclo as the engine for running potential field simulations. Add `choclo>=0.3.0` to the `environment.yml`.