### PR TITLE
Publish artifact after building website in PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       # Store the website as a build artifact so we can deploy it later
       - name: Upload HTML website as an artifact
         # Only if not a pull request
-        if: success() && github.event_name != 'pull_request'
+        if: success()
         uses: actions/upload-artifact@v4
         with:
           name: html-${{ github.sha }}


### PR DESCRIPTION
Make GitHub Actions to always publish built website as artifact, even if we are building in a PR. This way we can go download the built website to check it out locally.