### PR TITLE
Always upload artifact with built website

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,9 +40,9 @@ jobs:
           BASE_URL: /${{ github.event.repository.name }}
 
       # Store the website as a build artifact so we can deploy it later
+      # or preview the website in a PR.
       - name: Upload HTML website as an artifact
-        # Only if not a pull request
-        if: success() && github.event_name != 'pull_request'
+        if: success()
         uses: actions/upload-artifact@v4
         with:
           name: html-${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,14 @@ jobs:
       - name: Print MyST version
         run: myst --version
 
-      - name: Build website as static HTML
+      - name: Build website as static HTML (for PR)
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "Building MyST website without setting BASE_URL"
+          myst build --html
+
+      - name: Build website as static HTML (for deploy)
+        if: github.event_name != 'pull_request'
         run: |
           echo "Building MyST website using BASE_URL=" $BASE_URL
           myst build --html


### PR DESCRIPTION
This way we can preview the website in a PR, without having to build it locally. Build website without setting `BASE_URL` when it's done within a PR, so the built site can be previewed locally without path issues.